### PR TITLE
[not merging] Fix version constraints for older Cabal versions

### DIFF
--- a/stylish-cabal.cabal
+++ b/stylish-cabal.cabal
@@ -1,5 +1,5 @@
 name:               stylish-cabal
-version:            0.3.0.0
+version:            0.3.0.1
 synopsis:           Format Cabal files
 description:        A tool for nicely formatting your Cabal file.
 license:            BSD3

--- a/stylish-cabal.cabal
+++ b/stylish-cabal.cabal
@@ -46,13 +46,13 @@ library
                       Types.Block
                       Types.Field
   hs-source-dirs:     src
-  build-depends:      base            == 4.*
-                    , Cabal           == 2.0.*
+  build-depends:      base            >= 4.4 && < 4.11
+                    , Cabal           ^>= 2.0.0
                     , ansi-wl-pprint
                     , base-compat
                     , data-default
                     , deepseq
-                    , haddock-library
+                    , haddock-library ^>= 1.4.0
                     , mtl
                     , split
   default-language:   Haskell2010


### PR DESCRIPTION
0.3.0.0 wouldn't build on Hackage because it had no version constraint on haddock-library